### PR TITLE
Fix: Fields value in extra_user_fields jsonb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -818,6 +818,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux
 

--- a/app/models/concerns/decidim/extra_user_fields/organization_overrides.rb
+++ b/app/models/concerns/decidim/extra_user_fields/organization_overrides.rb
@@ -15,13 +15,12 @@ module Decidim
 
       def at_least_one_extra_field?
         extra_user_fields.reject { |key| key == "enabled" }
-                         .map { |_, value| value["enabled"] }
-                         .any? { |value| value == "1" }
+                         .map { |_, value| value["enabled"] }.any?
       end
 
       # Check if the given value is enabled in extra_user_fields
       def activated_extra_field?(sym)
-        extra_user_fields.dig(sym.to_s, "enabled") == "1"
+        extra_user_fields.dig(sym.to_s, "enabled") == true
       end
     end
   end

--- a/app/views/decidim/extra_user_fields/_registration_form.html.erb
+++ b/app/views/decidim/extra_user_fields/_registration_form.html.erb
@@ -1,4 +1,3 @@
-<%# byebug %>
 <% if current_organization.extra_user_fields_enabled? %>
   <div class="card">
     <div class="card__content card__extra_user_fields">

--- a/app/views/decidim/extra_user_fields/_registration_form.html.erb
+++ b/app/views/decidim/extra_user_fields/_registration_form.html.erb
@@ -1,3 +1,4 @@
+<%# byebug %>
 <% if current_organization.extra_user_fields_enabled? %>
   <div class="card">
     <div class="card__content card__extra_user_fields">

--- a/spec/models/decidim/organization_spec.rb
+++ b/spec/models/decidim/organization_spec.rb
@@ -12,9 +12,9 @@ module Decidim
         "date_of_birth" => date_of_birth
       }
     end
-    let(:extra_user_field) { "1" }
+    let(:extra_user_field) { true }
     let(:date_of_birth) do
-      { "enabled" => "1" }
+      { "enabled" => true }
     end
     let(:omniauth_secrets) do
       {

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -15,7 +15,7 @@ describe "Account", type: :system do
   # rubocop:disable Style/TrailingCommaInHashLiteral
   let(:extra_user_fields) do
     {
-      "enabled" => "1",
+      "enabled" => true,
       "date_of_birth" => date_of_birth,
       "postal_code" => postal_code,
       "gender" => gender,
@@ -30,27 +30,27 @@ describe "Account", type: :system do
   # rubocop:enable Style/TrailingCommaInHashLiteral
 
   let(:date_of_birth) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:postal_code) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:country) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:gender) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:phone_number) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:location) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   # Block ExtraUserFields RspecVar

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -39,7 +39,7 @@ describe "Extra user fields", type: :system do
   let(:extra_user_fields) do
     {
       # Block ExtraUserFields ExtraUserFields
-      "enabled" => "1",
+      "enabled" => true,
       "date_of_birth" => date_of_birth,
       "postal_code" => postal_code,
       "gender" => gender,
@@ -52,27 +52,27 @@ describe "Extra user fields", type: :system do
   # rubocop:enable Style/TrailingCommaInHashLiteral
 
   let(:date_of_birth) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:postal_code) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:country) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:gender) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:phone_number) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   let(:location) do
-    { "enabled" => "1" }
+    { "enabled" => true }
   end
 
   # Block ExtraUserFields RspecVar


### PR DESCRIPTION
#### Description

Current value does not allow to display form fields because it saves enabled value as `bool` when we try to find fields with value `"1"` and does not match